### PR TITLE
Add official verification

### DIFF
--- a/official_verification.md
+++ b/official_verification.md
@@ -1,5 +1,9 @@
 # Official Verification
 
+**Usage:** These links and other unique identifiers should be used to determine whether a source is officially from the QRL or the QRL foundation. 
+
+If you have concerns about services purporting to be related to the QRL or its affiliates please contact security@theqrl.org
+
 ## Website links
 
 - https://theqrl.org (and all subdomains)
@@ -9,6 +13,7 @@
 
 - Facebook: https://facebook.com/theqrl
 - Youtube: https://youtube.com/c/QRLedger
+- Discord: https://discord.com/channels/357604137204056065/
 - Twitter: https://twitter.com/qrledger
 - LinkedIn: https://www.linkedin.com/company/the-quantum-resistant-ledger/
 - Reddit: https://www.reddit.com/r/QRL

--- a/official_verification.md
+++ b/official_verification.md
@@ -1,0 +1,26 @@
+# Official Verification
+
+## Website links
+
+- https://theqrl.org (and all subdomains)
+- https://qrl.foundation
+
+## Communication/social platforms
+
+- Facebook: https://facebook.com/theqrl
+- Youtube: https://youtube.com/c/QRLedger
+- Twitter: https://twitter.com/qrledger
+- LinkedIn: https://www.linkedin.com/company/the-quantum-resistant-ledger/
+- Reddit: https://www.reddit.com/r/QRL
+- Telegram Group: https://t.me/QRLedgerOfficial
+- Telegram Announcements: https://t.me/TheQRLedger
+- Medium: https://www.medium.com/the-quantum-resistant-ledger (no longer in use)
+
+## Development related platforms
+
+- Github: https://www.github.com/theQRL/
+
+## App stores
+
+- iOS: https://apps.apple.com/ca/app/qrl-wallet/id1458620542
+- Android: https://play.google.com/store/apps/details?id=com.theqrl

--- a/official_verification.md
+++ b/official_verification.md
@@ -1,6 +1,6 @@
 # Official Verification
 
-**Usage:** These links and other unique identifiers should be used to determine whether a source is officially from the QRL or the QRL foundation. 
+**Usage:** These links and other unique identifiers should be used to determine whether a source is officially from the Quantum Resistant Ledger (QRL) or The QRL Foundation (Die QRL Stiftung). 
 
 If you have concerns about services purporting to be related to the QRL or its affiliates please contact security@theqrl.org
 


### PR DESCRIPTION
Official verification can be used to check whether a source is from the the Quantum Resistant Ledger (QRL) or the QRL Foundation.